### PR TITLE
1.21/mod menu fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,8 @@ repositories {
 		url = "https://api.modrinth.com/maven"
 
 	}
+
+	// Maven for ModMenu
 	maven { url "https://maven.terraformersmc.com/releases/" }
 
 }
@@ -57,6 +59,7 @@ dependencies {
 	//modImplementation include ("maven.modrinth:midnightlib:${project.midnightlib_version}")
 	include(modImplementation("maven.modrinth:midnightlib:${project.midnightlib_version}"))
 
+	// ModMenu is optional, but it's a nice to have for quality of life.
 	modImplementation "com.terraformersmc:modmenu:${project.modmenu_version}"
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ processResources {
 }
 
 tasks.withType(JavaCompile).configureEach {
-	it.options.release = 17
+	it.options.release = 21
 }
 
 java {
@@ -78,8 +78,8 @@ java {
 	// If you remove this line, sources will not be generated.
 	withSourcesJar()
 
-	sourceCompatibility = JavaVersion.VERSION_17
-	targetCompatibility = JavaVersion.VERSION_17
+	sourceCompatibility = JavaVersion.VERSION_21
+	targetCompatibility = JavaVersion.VERSION_21
 }
 
 jar {

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,8 @@ repositories {
 		url = "https://api.modrinth.com/maven"
 
 	}
+	maven { url "https://maven.terraformersmc.com/releases/" }
+
 }
 
 loom {
@@ -55,6 +57,7 @@ dependencies {
 	//modImplementation include ("maven.modrinth:midnightlib:${project.midnightlib_version}")
 	include(modImplementation("maven.modrinth:midnightlib:${project.midnightlib_version}"))
 
+	modImplementation "com.terraformersmc:modmenu:${project.modmenu_version}"
 }
 
 processResources {
@@ -66,7 +69,7 @@ processResources {
 }
 
 tasks.withType(JavaCompile).configureEach {
-	it.options.release = 21
+	it.options.release = 17
 }
 
 java {
@@ -75,8 +78,8 @@ java {
 	// If you remove this line, sources will not be generated.
 	withSourcesJar()
 
-	sourceCompatibility = JavaVersion.VERSION_21
-	targetCompatibility = JavaVersion.VERSION_21
+	sourceCompatibility = JavaVersion.VERSION_17
+	targetCompatibility = JavaVersion.VERSION_17
 }
 
 jar {

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,17 +4,17 @@ org.gradle.parallel=true
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.20.4
-yarn_mappings=1.20.4+build.3
+minecraft_version=1.21
+yarn_mappings=1.21+build.1
 loader_version=0.15.11
 
 # Mod Properties
-mod_version=1.5.1-1.20.4
+mod_version=1.5.1-1.21
 maven_group=com.phasesdiscord
 archives_base_name=phases-discord-rich-presence
 
 # Dependencies
-fabric_version=0.97.1+1.20.4
-midnightlib_version=1.5.3-fabric
-modmenu_version=9.0.0
+fabric_version=0.100.1+1.21
+midnightlib_version=1.5.6-fabric
+modmenu_version=11.0.1
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,15 +4,17 @@ org.gradle.parallel=true
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.21
-yarn_mappings=1.21+build.1
+minecraft_version=1.20.4
+yarn_mappings=1.20.4+build.3
 loader_version=0.15.11
 
 # Mod Properties
-mod_version=1.5.0
+mod_version=1.5.1-1.20.4
 maven_group=com.phasesdiscord
 archives_base_name=phases-discord-rich-presence
 
 # Dependencies
-fabric_version=0.100.1+1.21
-midnightlib_version=1.5.6-fabric
+fabric_version=0.97.1+1.20.4
+midnightlib_version=1.5.3-fabric
+modmenu_version=9.0.0
+

--- a/src/client/java/com/phasesdiscord/MenuIntegration.java
+++ b/src/client/java/com/phasesdiscord/MenuIntegration.java
@@ -5,7 +5,15 @@ import com.terraformersmc.modmenu.api.ConfigScreenFactory;
 import com.terraformersmc.modmenu.api.ModMenuApi;
 import eu.midnightdust.lib.config.MidnightConfig;
 
+/**
+ * ModMenu integration class
+ */
 public class MenuIntegration implements ModMenuApi {
+
+    /**
+     * Get the config screen factory
+     * @return the config screen factory
+     */
     @Override
     public ConfigScreenFactory<?> getModConfigScreenFactory() {
         return parent -> MidnightConfig.getScreen(parent, "phases-discord-rich-presence");

--- a/src/client/java/com/phasesdiscord/MenuIntegration.java
+++ b/src/client/java/com/phasesdiscord/MenuIntegration.java
@@ -1,0 +1,13 @@
+package com.phasesdiscord;
+
+
+import com.terraformersmc.modmenu.api.ConfigScreenFactory;
+import com.terraformersmc.modmenu.api.ModMenuApi;
+import eu.midnightdust.lib.config.MidnightConfig;
+
+public class MenuIntegration implements ModMenuApi {
+    @Override
+    public ConfigScreenFactory<?> getModConfigScreenFactory() {
+        return parent -> MidnightConfig.getScreen(parent, "phases-discord-rich-presence");
+    }
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -34,8 +34,8 @@
 	],
 	"depends": {
 		"fabricloader": ">=0.15.11",
-		"minecraft": "~1.20.4",
-		"java": ">=17",
+		"minecraft": "~1.21.0",
+		"java": ">=21",
 		"fabric-api": "*"
 	},
 	"suggests": {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -20,6 +20,9 @@
 		],
 		"client": [
 			"com.phasesdiscord.PhaseDiscordClient"
+		],
+		"modmenu": [
+			"com.phasesdiscord.MenuIntegration"
 		]
 	},
 	"mixins": [
@@ -31,11 +34,11 @@
 	],
 	"depends": {
 		"fabricloader": ">=0.15.11",
-		"minecraft": "~1.21.0",
-		"java": ">=21",
+		"minecraft": "~1.20.4",
+		"java": ">=17",
 		"fabric-api": "*"
 	},
 	"suggests": {
-		"another-mod": "*"
+		"modmenu": "*"
 	}
 }


### PR DESCRIPTION
### Fix Mod Menu Integration

Hi, I noticed that Mod Menu was not working with this mod, so I decided to try and fix it (even though I've never done any Minecraft modding before).

Well, it's fixed now!

I have changed the version to `1.5.1-1.21`. This adds more clarity and makes it easier to update versions `1.20.1` and `1.20.4`, which are among the more commonly used versions. If you don't like it, you can change it!