### PR TITLE
Fixed a bug in non-English environments where the main hand was considered to be holding an item even though it was not holding an item

### DIFF
--- a/src/client/java/com/phasesdiscord/PhaseDiscordClient.java
+++ b/src/client/java/com/phasesdiscord/PhaseDiscordClient.java
@@ -6,6 +6,7 @@ import eu.midnightdust.lib.config.MidnightConfig;
 import net.fabricmc.api.ClientModInitializer;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
 import net.minecraft.util.Hand;
 import net.minecraft.world.dimension.DimensionType;
 import org.slf4j.Logger;
@@ -160,7 +161,7 @@ public class PhaseDiscordClient implements ClientModInitializer {
                 } else {
                     ItemStack held_item = client.player.getStackInHand(Hand.MAIN_HAND);
                     String item_name = held_item.getName().getString();
-                    if (!item_name.equals("Air")) {
+                    if (!item_name.equals(Items.AIR.getName().getString())) {
                         presence.details = "Holding " + item_name;
                     }
                 }
@@ -313,7 +314,7 @@ public class PhaseDiscordClient implements ClientModInitializer {
             {
                 ItemStack held_item = client.player.getStackInHand(Hand.MAIN_HAND);
                 item_name = held_item.getName().getString();
-                if(!item_name.equals("Air"))
+                if(!item_name.equals(Items.AIR.getName().getString()))
                 {
                     presence.details = PhaseDiscordConfig.mainAdvancedModeDetailWhenHoldingItem.replace("{item_name}", item_name);
                 }


### PR DESCRIPTION
In the current version, if the Minecraft client is in a non-English language, when not holding any items, it will be misjudged because `client.player.getStackInHand(Hand.MAIN_HAND).getName().getString()` gets the name of the corresponding language instead of the English "Air", which actually displays "Holding Air".

<details>
    <summary>Screenshot</summary>
    <img width="1920" alt="Snipaste_2024-11-05_07-25-53" src="https://github.com/user-attachments/assets/67ca807e-c39b-40a2-9ea5-0fbbf4ddb7f9">
</details>