### PR TITLE
Migrating deprecated APIs to the new version

### DIFF
--- a/src/client/java/com/phasesdiscord/PhaseDiscordClient.java
+++ b/src/client/java/com/phasesdiscord/PhaseDiscordClient.java
@@ -2,9 +2,8 @@ package com.phasesdiscord;
 
 import eu.midnightdust.lib.config.MidnightConfig;
 import net.fabricmc.api.ClientModInitializer;
-import net.fabricmc.fabric.api.resource.ResourceManagerHelper;
-import net.fabricmc.fabric.api.resource.SimpleSynchronousResourceReloadListener;
-import net.minecraft.resource.ResourceManager;
+import net.fabricmc.fabric.api.resource.v1.ResourceLoader;
+import net.fabricmc.fabric.api.resource.v1.reloader.SimpleResourceReloader;
 import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 import org.slf4j.Logger;
@@ -18,7 +17,6 @@ import static net.minecraft.resource.ResourceType.CLIENT_RESOURCES;
 public class PhaseDiscordClient implements ClientModInitializer {
 
     public static boolean loadSuccess = false;
-
     //logger
     public static final Logger LOGGER = LoggerFactory.getLogger("phases-discord-rich-presence");
 
@@ -26,18 +24,15 @@ public class PhaseDiscordClient implements ClientModInitializer {
     public void onInitializeClient()
     {
         //config stuff
-        ResourceManagerHelper.get(CLIENT_RESOURCES).registerReloadListener(new SimpleSynchronousResourceReloadListener()
-        {
+        ResourceLoader.get(CLIENT_RESOURCES).registerReloader(Identifier.of("phases-discord-rich-presence", "discord-rich-presence"), new SimpleResourceReloader<Void>() {
             // After all the resource files have been loaded, the Modmenu configuration interface is provided so that the text translation works properly
             @Override
-            public Identifier getFabricId()
-            {
-                return Identifier.of("phases-discord-rich-presence", "discord-rich-presence");
-            }
+            protected Void prepare(Store store) {
+                // It's useless, just leave it blank
+                return null; }
 
             @Override
-            public void reload(ResourceManager manager)
-            {
+            protected void apply(Void unused, Store store) {
                 mainAdvancedModeDetail = Text.translatableWithFallback("phases-discord-rich-presence.midnightconfig.mainAdvancedModeDetailTextField", "Playing Minecraft").getString();
                 mainAdvancedModeDetailWhenHoldingItem = Text.translatableWithFallback("phases-discord-rich-presence.midnightconfig.mainAdvancedModeDetailWhenHoldingItemTextField", "Holding %s").getString();
                 mainAdvancedModeStateMultiplayer = Text.translatableWithFallback("phases-discord-rich-presence.midnightconfig.mainAdvancedModeStateMultiplayerTextField", "Playing Multiplayer on %s with %s players").getString();

--- a/src/client/java/com/phasesdiscord/PhaseDiscordClient.java
+++ b/src/client/java/com/phasesdiscord/PhaseDiscordClient.java
@@ -17,14 +17,15 @@ import static net.minecraft.resource.ResourceType.CLIENT_RESOURCES;
 public class PhaseDiscordClient implements ClientModInitializer {
 
     public static boolean loadSuccess = false;
+    public static final String ModID = "phases-discord-rich-presence";
     //logger
-    public static final Logger LOGGER = LoggerFactory.getLogger("phases-discord-rich-presence");
+    public static final Logger LOGGER = LoggerFactory.getLogger(ModID);
 
     @Override
     public void onInitializeClient()
     {
         //config stuff
-        ResourceLoader.get(CLIENT_RESOURCES).registerReloader(Identifier.of("phases-discord-rich-presence", "discord-rich-presence"), new SimpleResourceReloader<Void>() {
+        ResourceLoader.get(CLIENT_RESOURCES).registerReloader(Identifier.of(ModID, "discord-rich-presence"), new SimpleResourceReloader<Void>() {
             // After all the resource files have been loaded, the Modmenu configuration interface is provided so that the text translation works properly
             @Override
             protected Void prepare(Store store) {
@@ -45,10 +46,10 @@ public class PhaseDiscordClient implements ClientModInitializer {
                 advancedModeDimensionCustom = Text.translatableWithFallback("phases-discord-rich-presence.midnightconfig.advancedModeDimensionCustomTextField", "In %s Dimension").getString();
                 advancedModeMainMenuText = Text.translatableWithFallback("phases-discord-rich-presence.midnightconfig.advancedModeMainMenuTextTextField", "Main Menu").getString();
 
-                MidnightConfig.init("phases-discord-rich-presence", PhaseDiscordConfig.class);
+                MidnightConfig.init(ModID, PhaseDiscordConfig.class);
                 try {
                     Class.forName("com.terraformersmc.modmenu.api.ModMenuApi");
-                    configScreenFactory = parent -> MidnightConfig.getScreen(parent, "phases-discord-rich-presence");
+                    configScreenFactory = parent -> MidnightConfig.getScreen(parent, ModID);
                     loadSuccess = true;
                 } catch (ClassNotFoundException ignored) {
                 }


### PR DESCRIPTION
The `net.fabricmc.fabric.api.resource.ResourceManagerHelper.registerReloadListener` and `net.fabricmc.fabric.api.resource. SimpleSynchronousResourceReloadListener` have been marked as `@Deprecated`. Consequently, I have replaced them with the new `net.fabricmc.fabric.api.resource.v1.ResourceLoader.registerReloader(Identifier, ResourceReloader)` and `net.fabricmc.fabric.api.resource.v1.reloader.SimpleResourceReloader<T>`.