### PR TITLE
Simplifying Text Translation-Related Code

### DIFF
--- a/src/client/java/com/phasesdiscord/PhaseDiscordClient.java
+++ b/src/client/java/com/phasesdiscord/PhaseDiscordClient.java
@@ -38,17 +38,17 @@ public class PhaseDiscordClient implements ClientModInitializer {
             @Override
             public void reload(ResourceManager manager)
             {
-                mainAdvancedModeDetail = Text.translatableWithFallback("phases-discord-rich-presence.midnightconfig.mainAdvancedModeDetailTextField", "Playing Minecraft").getString();
-                mainAdvancedModeDetailWhenHoldingItem = Text.translatableWithFallback("phases-discord-rich-presence.midnightconfig.mainAdvancedModeDetailWhenHoldingItemTextField", "Holding %s").getString();
-                mainAdvancedModeStateMultiplayer = Text.translatableWithFallback("phases-discord-rich-presence.midnightconfig.mainAdvancedModeStateMultiplayerTextField", "Playing Multiplayer on %s with %s players").getString();
-                mainAdvancedModeStateMultiplayerPause = Text.translatableWithFallback("phases-discord-rich-presence.midnightconfig.mainAdvancedModeStateMultiplayerPauseTextField", "Playing multiplayer on %s with %s players - Paused").getString();
-                mainAdvancedModeStateSingleplayer = Text.translatableWithFallback("phases-discord-rich-presence.midnightconfig.mainAdvancedModeStateSingleplayerTextField", "Playing Singleplayer").getString();
-                mainAdvancedModeStateSingleplayerPause = Text.translatableWithFallback("phases-discord-rich-presence.midnightconfig.mainAdvancedModeStateSingleplayerPauseTextField", "Playing Singleplayer - Paused").getString();
-                advancedModeDimensionOverworld = Text.translatableWithFallback("phases-discord-rich-presence.midnightconfig.advancedModeDimensionOverworldTextField", "In The Overworld").getString();
-                advancedModeDimensionNether = Text.translatableWithFallback("phases-discord-rich-presence.midnightconfig.advancedModeDimensionNetherTextField", "In The Nether").getString();
-                advancedModeDimensionEnd = Text.translatableWithFallback("phases-discord-rich-presence.midnightconfig.advancedModeDimensionEndTextField", "In The End").getString();
-                advancedModeDimensionCustom = Text.translatableWithFallback("phases-discord-rich-presence.midnightconfig.advancedModeDimensionCustomTextField", "In %s Dimension").getString();
-                advancedModeMainMenuText = Text.translatableWithFallback("phases-discord-rich-presence.midnightconfig.advancedModeMainMenuTextTextField", "Main Menu").getString();
+                mainAdvancedModeDetail = Text.translatable("phases-discord-rich-presence.midnightconfig.mainAdvancedModeDetailTextField").getString();
+                mainAdvancedModeDetailWhenHoldingItem = Text.translatable("phases-discord-rich-presence.midnightconfig.mainAdvancedModeDetailWhenHoldingItemTextField").getString();
+                mainAdvancedModeStateMultiplayer = Text.translatable("phases-discord-rich-presence.midnightconfig.mainAdvancedModeStateMultiplayerTextField").getString();
+                mainAdvancedModeStateMultiplayerPause = Text.translatable("phases-discord-rich-presence.midnightconfig.mainAdvancedModeStateMultiplayerPauseTextField").getString();
+                mainAdvancedModeStateSingleplayer = Text.translatable("phases-discord-rich-presence.midnightconfig.mainAdvancedModeStateSingleplayerTextField").getString();
+                mainAdvancedModeStateSingleplayerPause = Text.translatable("phases-discord-rich-presence.midnightconfig.mainAdvancedModeStateSingleplayerPauseTextField").getString();
+                advancedModeDimensionOverworld = Text.translatable("phases-discord-rich-presence.midnightconfig.advancedModeDimensionOverworldTextField").getString();
+                advancedModeDimensionNether = Text.translatable("phases-discord-rich-presence.midnightconfig.advancedModeDimensionNetherTextField").getString();
+                advancedModeDimensionEnd = Text.translatable("phases-discord-rich-presence.midnightconfig.advancedModeDimensionEndTextField").getString();
+                advancedModeDimensionCustom = Text.translatable("phases-discord-rich-presence.midnightconfig.advancedModeDimensionCustomTextField").getString();
+                advancedModeMainMenuText = Text.translatable("phases-discord-rich-presence.midnightconfig.advancedModeMainMenuTextTextField").getString();
 
                 MidnightConfig.init("phases-discord-rich-presence", PhaseDiscordConfig.class);
                 try {

--- a/src/client/java/com/phasesdiscord/RPC.java
+++ b/src/client/java/com/phasesdiscord/RPC.java
@@ -346,7 +346,7 @@ public class RPC
                     }
                     else
                     {
-                        finalResult = "Playing Minecraft";
+                        finalResult = Text.translatable("phases-discord-rich-presence.midnightconfig.mainAdvancedModeDetailTextField").getString();
                     }
                 }
 

--- a/src/client/java/com/phasesdiscord/RPC.java
+++ b/src/client/java/com/phasesdiscord/RPC.java
@@ -140,17 +140,17 @@ public class RPC
 
                                         if(!PhaseDiscordConfig.showPaused)
                                         {
-                                            activity.setState(Text.translatableWithFallback("phases-discord-rich-presence.midnightconfig.mainAdvancedModeStateSingleplayerTextField", "Playing Singleplayer").getString());
+                                            activity.setState(Text.translatable("phases-discord-rich-presence.midnightconfig.mainAdvancedModeStateSingleplayerTextField").getString());
                                         }
                                         else
                                         {
                                             if(client.currentScreen != null)
                                             {
-                                                activity.setState(Text.translatableWithFallback("phases-discord-rich-presence.midnightconfig.mainAdvancedModeStateSingleplayerPauseTextField", "Playing Singleplayer - Paused").getString());
+                                                activity.setState(Text.translatable("phases-discord-rich-presence.midnightconfig.mainAdvancedModeStateSingleplayerPauseTextField").getString());
                                             }
                                             else
                                             {
-                                                activity.setState(Text.translatableWithFallback("phases-discord-rich-presence.midnightconfig.mainAdvancedModeStateSingleplayerTextField", "Playing Singleplayer").getString());
+                                                activity.setState(Text.translatable("phases-discord-rich-presence.midnightconfig.mainAdvancedModeStateSingleplayerTextField").getString());
                                             }
                                         }
                                     }
@@ -217,9 +217,8 @@ public class RPC
                                     String stateKey = getSimpleMultiplayerKey(client.currentScreen != null && PhaseDiscordConfig.showPaused);
                                     Object[] args = getSimpleMultiplayerArgs(serverIP, client.world.getPlayers().size());
 
-                                    activity.setState(Text.translatableWithFallback(
+                                    activity.setState(Text.translatable(
                                             stateKey,
-                                            getFallbackString(stateKey),
                                             args
                                     ).getString());
                                 }
@@ -249,7 +248,7 @@ public class RPC
                                     }
                                     else
                                     {
-                                        activity.setDetails(Text.translatableWithFallback("phases-discord-rich-presence.midnightconfig.advancedModeMainMenuTextTextField","Main Menu").getString());
+                                        activity.setDetails(Text.translatable("phases-discord-rich-presence.midnightconfig.advancedModeMainMenuTextTextField").getString());
                                     }
 
                                     activity.assets().setLargeText(PhaseDiscordConfig.advancedModeLargeText); //to be changed via options eventually
@@ -258,7 +257,7 @@ public class RPC
                                 else //simple mode
                                 {
                                     activity.assets().setLargeImage("base");
-                                    activity.setDetails(Text.translatableWithFallback("phases-discord-rich-presence.midnightconfig.advancedModeMainMenuTextTextField","Main Menu").getString());
+                                    activity.setDetails(Text.translatable("phases-discord-rich-presence.midnightconfig.advancedModeMainMenuTextTextField").getString());
                                     activity.assets().setLargeText("Phase's Minecraft Discord Rich Presence");
                                     if(PhaseDiscordConfig.showPlayerHeadAndUsername)
                                     {
@@ -337,13 +336,13 @@ public class RPC
             {
                 if(PhaseDiscordConfig.enableItem == false)
                 {
-                    finalResult = Text.translatableWithFallback("phases-discord-rich-presence.midnightconfig.mainAdvancedModeDetailTextField","Playing Minecraft").getString();
+                    finalResult = Text.translatable("phases-discord-rich-presence.midnightconfig.mainAdvancedModeDetailTextField").getString();
                 }
                 else
                 {
                     if(!item_name.equals(Items.AIR.getName().getString()))
                     {
-                        finalResult = Text.translatableWithFallback("phases-discord-rich-presence.midnightconfig.mainAdvancedModeDetailWhenHoldingItemTextField","Holding" + item_name, item_name).getString();
+                        finalResult = Text.translatable("phases-discord-rich-presence.midnightconfig.mainAdvancedModeDetailWhenHoldingItemTextField", item_name).getString();
                     }
                     else
                     {
@@ -429,7 +428,7 @@ public class RPC
                 else
                 {
                     presence.assets().setLargeImage("overworld");
-                    presence.assets().setLargeText(Text.translatableWithFallback("phases-discord-rich-presence.midnightconfig.advancedModeDimensionOverworldTextField","In The Overworld").getString());
+                    presence.assets().setLargeText(Text.translatable("phases-discord-rich-presence.midnightconfig.advancedModeDimensionOverworldTextField").getString());
                 }
             }
             else if(dimensionName.equals("minecraft:the_nether"))
@@ -442,7 +441,7 @@ public class RPC
                 else
                 {
                     presence.assets().setLargeImage("nether");
-                    presence.assets().setLargeText(Text.translatableWithFallback("phases-discord-rich-presence.midnightconfig.advancedModeDimensionNetherTextField","In The Nether").getString());
+                    presence.assets().setLargeText(Text.translatable("phases-discord-rich-presence.midnightconfig.advancedModeDimensionNetherTextField").getString());
                 }
             }
             else if(dimensionName.equals("minecraft:the_end"))
@@ -455,7 +454,7 @@ public class RPC
                 else
                 {
                     presence.assets().setLargeImage("the_end");
-                    presence.assets().setLargeText(Text.translatableWithFallback("phases-discord-rich-presence.midnightconfig.advancedModeDimensionEndTextField","In The End").getString());
+                    presence.assets().setLargeText(Text.translatable("phases-discord-rich-presence.midnightconfig.advancedModeDimensionEndTextField").getString());
                 }
             }
             else
@@ -601,23 +600,6 @@ public class RPC
         else //more players
         {
             return Text.translatable("phases-discord-rich-presence.multiplayer.players.other", playerCount).getString();
-        }
-    }
-
-    //gets fallback string *just* in case something bad happens
-    public static String getFallbackString(String key)
-    {
-        switch(key)
-        {
-            case "phases-discord-rich-presence.multiplayer.full": return "Playing Multiplayer on %s with %s";
-            case "phases-discord-rich-presence.multiplayer.full.paused": return "Playing Multiplayer on %s with %s - Paused";
-            case "phases-discord-rich-presence.multiplayer.serverOnly": return "Playing Multiplayer on %s";
-            case "phases-discord-rich-presence.multiplayer.serverOnly.paused": return "Playing Multiplayer on %s - Paused";
-            case "phases-discord-rich-presence.multiplayer.playerCountOnly": return "Playing Multiplayer with %s";
-            case "phases-discord-rich-presence.multiplayer.playerCountOnly.paused": return "Playing Multiplayer with %s - Paused";
-            case "phases-discord-rich-presence.multiplayer.base": return "Playing Multiplayer";
-            case "phases-discord-rich-presence.multiplayer.base.paused": return "Playing Multiplayer - Paused";
-            default: return "Playing Multiplayer"; //should never reach here, but let's play it safe
         }
     }
 

--- a/src/client/java/phasesdiscordConfigStuff/PhaseDiscordConfig.java
+++ b/src/client/java/phasesdiscordConfigStuff/PhaseDiscordConfig.java
@@ -33,23 +33,23 @@ public class PhaseDiscordConfig extends MidnightConfig
     @Comment(category = ADVANCED) public static Comment advanceExplain;
     @Comment(category = ADVANCED) public static Comment advanceExplain2;
 
-    @Entry(category = ADVANCED) public static String mainAdvancedModeDetail = Text.translatableWithFallback("phases-discord-rich-presence.midnightconfig.mainAdvancedModeDetailTextField","Playing Minecraft").getString();
-    @Entry(category = ADVANCED) public static String mainAdvancedModeDetailWhenHoldingItem = Text.translatableWithFallback("phases-discord-rich-presence.midnightconfig.mainAdvancedModeDetailWhenHoldingItemTextField","Holding %s").getString();
+    @Entry(category = ADVANCED) public static String mainAdvancedModeDetail = Text.translatable("phases-discord-rich-presence.midnightconfig.mainAdvancedModeDetailTextField").getString();
+    @Entry(category = ADVANCED) public static String mainAdvancedModeDetailWhenHoldingItem = Text.translatable("phases-discord-rich-presence.midnightconfig.mainAdvancedModeDetailWhenHoldingItemTextField").getString();
 
-    @Entry(category = ADVANCED) public static String mainAdvancedModeStateMultiplayer = Text.translatableWithFallback("phases-discord-rich-presence.midnightconfig.mainAdvancedModeStateMultiplayerTextField","Playing Multiplayer on %s with %s players").getString();
-    @Entry(category = ADVANCED) public static String mainAdvancedModeStateMultiplayerPause = Text.translatableWithFallback("phases-discord-rich-presence.midnightconfig.mainAdvancedModeStateMultiplayerPauseTextField","Playing Multiplayer on %s with %s players - Paused").getString();
+    @Entry(category = ADVANCED) public static String mainAdvancedModeStateMultiplayer = Text.translatable("phases-discord-rich-presence.midnightconfig.mainAdvancedModeStateMultiplayerTextField").getString();
+    @Entry(category = ADVANCED) public static String mainAdvancedModeStateMultiplayerPause = Text.translatable("phases-discord-rich-presence.midnightconfig.mainAdvancedModeStateMultiplayerPauseTextField").getString();
 
-    @Entry(category = ADVANCED) public static String mainAdvancedModeStateSingleplayer = Text.translatableWithFallback("phases-discord-rich-presence.midnightconfig.mainAdvancedModeStateSingleplayerTextField","Playing Singleplayer").getString();;
-    @Entry(category = ADVANCED) public static String mainAdvancedModeStateSingleplayerPause = Text.translatableWithFallback("phases-discord-rich-presence.midnightconfig.mainAdvancedModeStateSingleplayerPauseTextField","Playing Singleplayer - Paused").getString();;
+    @Entry(category = ADVANCED) public static String mainAdvancedModeStateSingleplayer = Text.translatable("phases-discord-rich-presence.midnightconfig.mainAdvancedModeStateSingleplayerTextField").getString();;
+    @Entry(category = ADVANCED) public static String mainAdvancedModeStateSingleplayerPause = Text.translatable("phases-discord-rich-presence.midnightconfig.mainAdvancedModeStateSingleplayerPauseTextField").getString();;
 
-    @Entry(category = ADVANCED) public static String advancedModeDimensionOverworld = Text.translatableWithFallback("phases-discord-rich-presence.midnightconfig.advancedModeDimensionOverworldTextField","In The Overworld").getString();;
-    @Entry(category = ADVANCED) public static String advancedModeDimensionNether = Text.translatableWithFallback("phases-discord-rich-presence.midnightconfig.advancedModeDimensionNetherTextField","In The Nether").getString();;
-    @Entry(category = ADVANCED) public static String advancedModeDimensionEnd = Text.translatableWithFallback("phases-discord-rich-presence.midnightconfig.advancedModeDimensionEndTextField","In The End").getString();;
-    @Entry(category = ADVANCED) public static String advancedModeDimensionCustom = Text.translatableWithFallback("phases-discord-rich-presence.midnightconfig.advancedModeDimensionCustomTextField","In %s Dimension").getString();;
+    @Entry(category = ADVANCED) public static String advancedModeDimensionOverworld = Text.translatable("phases-discord-rich-presence.midnightconfig.advancedModeDimensionOverworldTextField").getString();;
+    @Entry(category = ADVANCED) public static String advancedModeDimensionNether = Text.translatable("phases-discord-rich-presence.midnightconfig.advancedModeDimensionNetherTextField").getString();;
+    @Entry(category = ADVANCED) public static String advancedModeDimensionEnd = Text.translatable("phases-discord-rich-presence.midnightconfig.advancedModeDimensionEndTextField").getString();;
+    @Entry(category = ADVANCED) public static String advancedModeDimensionCustom = Text.translatable("phases-discord-rich-presence.midnightconfig.advancedModeDimensionCustomTextField").getString();;
 
     @Entry(category = ADVANCED) public static boolean advancedModeChangeMainMenuText = false;
 
-    @Entry(category = ADVANCED) public static String advancedModeMainMenuText = Text.translatableWithFallback("phases-discord-rich-presence.midnightconfig.advancedModeMainMenuTextTextField","Main Menu").getString();
+    @Entry(category = ADVANCED) public static String advancedModeMainMenuText = Text.translatable("phases-discord-rich-presence.midnightconfig.advancedModeMainMenuTextTextField").getString();
 
     @Entry(category = ADVANCED) public static String advancedModeLargeText = "Phase's Discord Rich Presence";
 


### PR DESCRIPTION
As this mod is purely client-side, theoretically no additional fallback text is required once complete `en_us` text is provided as a fallback.
Removing the fallback text yields identical results, but doing so eliminates the need to repeatedly provide redundant fallback text, thereby simplifying the process.
I was unfamiliar with this mechanism when initially implementing this feature, and this was an error made during that development phase. My sincere apologies.

Additionally, I've discovered that in Simple Mode, when displaying held item names and the player holds nothing, the final DRP text setting isn't utilising the translation. As it only affects a single line, I've refrained from opening a new PR for this.